### PR TITLE
fix(geolocationTool): don't misinterpret search query with E or W for latlng

### DIFF
--- a/grails-app/views/transcribe/_geolocationTool.gsp
+++ b/grails-app/views/transcribe/_geolocationTool.gsp
@@ -198,8 +198,8 @@
 
   function parse_gps(input){
 
-    if( input.indexOf( 'N' ) == -1 && input.indexOf( 'S' ) == -1 &&
-        input.indexOf( 'W' ) == -1 && input.indexOf( 'E' ) == -1 ) {
+    // Only parse as coordinates if in some degree/hour/minute N/S/E/W form
+    if (!/^([nwse]?\s*(\d+[°'"]\s*){1,3}\s*[nwse]?\s*){2}$/i.test(input)) {
         return input.split(',');
     }
 


### PR DESCRIPTION
Fixes AgentschapPlantentuinMeise/DoeDat-dev/issues/41

I'm not exactly sure how which formats the GPS parsing method supports. Something like `12°1" 3'N 67°22"2'E` will pass to the LatLng parser instead of address search.