### PR TITLE
feat: protect admin-only routes

### DIFF
--- a/grails-app/conf/application.yml
+++ b/grails-app/conf/application.yml
@@ -152,7 +152,7 @@ security:
     cas:
         adminRole: "ROLE_VP_ADMIN"
         validatorRole: "ROLE_VP_VALIDATOR"
-        uriFilterPattern: '/validate/save.*,/validate/.*,/user/.*,/project/((?!index).)*,/task/.*,/newsItem/.*,/picklist/.*,/admin,/admin/.*,/frontPage/.*,/ajax/userReport,/ws/userReport,/transcribe/.*,/taskComment/((?!getCommentsAjax).)*,/locality/.*,/collectionEvent/.*,/ajax/keepSessionAlive.*,/ws/keepSessionAlive.*,/forum/.*,/template/.*,/monitoring,/metrics,/metrics/.*,/ws/acceptAchievements,/ajax/acceptAchievements,/project/createNewProject.*'
+        uriFilterPattern: '/validate/save.*,/validate/.*,/user/.*,/project/((?!index).)*,/task/.*,/newsItem/.*,/picklist/.*,/admin,/admin/.*,/frontPage/.*,/ajax/userReport,/ws/userReport,/transcribe/.*,/taskComment/((?!getCommentsAjax).)*,/locality/.*,/collectionEvent/.*,/ajax/keepSessionAlive.*,/ws/keepSessionAlive.*,/forum/.*,/template/.*,/monitoring,/metrics,/metrics/.*,/ws/acceptAchievements,/ajax/acceptAchievements,/project/createNewProject.*,/validationRule/.*,/stats/.*,/setting/.*'
         authenticateOnlyIfLoggedInPattern: '/,/;jsessionid=.*,/project/index/.*,/tutorials/.*,/institution/.*,/buildInfo,/events/.*,/es,/eventSource.*'
         uriExclusionFilterPattern: '/assets/.*,/static/.*,/fonts/.*,/images/.*,/css/.*,/js/.*,/less/.*'
 bvp:

--- a/grails-app/controllers/au/org/ala/volunteer/AdminController.groovy
+++ b/grails-app/controllers/au/org/ala/volunteer/AdminController.groovy
@@ -1,5 +1,6 @@
 package au.org.ala.volunteer
 
+import au.org.ala.web.AlaSecured
 import groovy.time.TimeCategory
 import org.elasticsearch.action.search.SearchType
 import grails.plugins.csv.CSVWriter
@@ -9,6 +10,7 @@ import org.springframework.web.multipart.MultipartFile
 
 import java.text.SimpleDateFormat
 
+@AlaSecured(value = ["ROLE_VP_ADMIN"], redirectController = "index")
 class AdminController {
 
     def taskService

--- a/grails-app/controllers/au/org/ala/volunteer/FrontPageController.groovy
+++ b/grails-app/controllers/au/org/ala/volunteer/FrontPageController.groovy
@@ -3,10 +3,12 @@ package au.org.ala.volunteer
 import grails.transaction.Transactional
 import org.springframework.web.multipart.MultipartFile
 
+import au.org.ala.web.AlaSecured
+
+@AlaSecured(value = ["ROLE_VP_ADMIN"], redirectController = "index")
 class FrontPageController {
 
     def index() {
-
         redirect(action: "edit", params: params)
     }
 

--- a/grails-app/controllers/au/org/ala/volunteer/PicklistController.groovy
+++ b/grails-app/controllers/au/org/ala/volunteer/PicklistController.groovy
@@ -5,11 +5,13 @@ import grails.converters.JSON
 import groovy.json.JsonOutput
 import org.apache.commons.lang3.StringEscapeUtils
 import grails.plugins.csv.CSVWriter
+import static javax.servlet.http.HttpServletResponse.SC_FORBIDDEN
 
 class PicklistController {
 
     static allowedMethods = [upload: "POST", save: "POST", update: "POST", delete: "POST"]
 
+    def userService
     def picklistService
     def imagesWebService
     def imageServiceService
@@ -37,6 +39,10 @@ class PicklistController {
     }
 
     def manage () {
+        if (!userService.isAdmin()) {
+            response.sendError(SC_FORBIDDEN)
+        }
+
         def picklistInstitutionCodes = [""]
         picklistInstitutionCodes.addAll(picklistService.getInstitutionCodes())
         [picklistInstanceList: Picklist.list(), collectionCodes: picklistInstitutionCodes]

--- a/grails-app/controllers/au/org/ala/volunteer/ProjectController.groovy
+++ b/grails-app/controllers/au/org/ala/volunteer/ProjectController.groovy
@@ -392,6 +392,10 @@ class ProjectController {
     }
 
     def editGeneralSettings() {
+        if (!userService.isAdmin()) {
+            response.sendError(SC_FORBIDDEN, message(code: 'project.backend.permssion'))
+        }
+
         def projectInstance = Project.get(params.int("id"))
         if (!projectInstance) {
             flash.message = "${message(code: 'default.not.found.message', args: [message(code: 'project.label', default: 'Project'), params.id])}"
@@ -411,6 +415,10 @@ class ProjectController {
     }
 
     def editTutorialLinksSettings() {
+        if (!userService.isAdmin()) {
+            response.sendError(SC_FORBIDDEN, message(code: 'project.backend.permssion'))
+        }
+
         def projectInstance = Project.get(params.int("id"))
         if (!projectInstance) {
             flash.message = "${message(code: 'default.not.found.message', args: [message(code: 'project.label', default: 'Project'), params.id])}"
@@ -421,6 +429,10 @@ class ProjectController {
     }
 
     def editPicklistSettings() {
+        if (!userService.isAdmin()) {
+            response.sendError(SC_FORBIDDEN, message(code: 'project.backend.permssion'))
+        }
+
         def projectInstance = Project.get(params.int("id"))
         if (!projectInstance) {
             flash.message = "${message(code: 'default.not.found.message', args: [message(code: 'project.label', default: 'Project'), params.id])}"
@@ -434,6 +446,10 @@ class ProjectController {
     }
 
     def editMapSettings() {
+        if (!userService.isAdmin()) {
+            response.sendError(SC_FORBIDDEN, message(code: 'project.backend.permssion'))
+        }
+
         def projectInstance = Project.get(params.int("id"))
         if (!projectInstance) {
             flash.message = "${message(code: 'default.not.found.message', args: [message(code: 'project.label', default: 'Project'), params.id])}"
@@ -444,6 +460,10 @@ class ProjectController {
     }
 
     def editBannerImageSettings() {
+        if (!userService.isAdmin()) {
+            response.sendError(SC_FORBIDDEN, message(code: 'project.backend.permssion'))
+        }
+
         def projectInstance = Project.get(params.int("id"))
         if (!projectInstance) {
             flash.message = "${message(code: 'default.not.found.message', args: [message(code: 'project.label', default: 'Project'), params.id])}"
@@ -454,6 +474,10 @@ class ProjectController {
     }
 
     def editBackgroundImageSettings() {
+        if (!userService.isAdmin()) {
+            response.sendError(SC_FORBIDDEN, message(code: 'project.backend.permssion'))
+        }
+
         def projectInstance = Project.get(params.int("id"))
         if (!projectInstance) {
             flash.message = "${message(code: 'default.not.found.message', args: [message(code: 'project.label', default: 'Project'), params.id])}"
@@ -464,6 +488,10 @@ class ProjectController {
     }
 
     def editTaskSettings() {
+        if (!userService.isAdmin()) {
+            response.sendError(SC_FORBIDDEN, message(code: 'project.backend.permssion'))
+        }
+
         def projectInstance = Project.get(params.int("id"))
         if (!projectInstance) {
             flash.message = "${message(code: 'default.not.found.message', args: [message(code: 'project.label', default: 'Project'), params.id])}"
@@ -475,6 +503,10 @@ class ProjectController {
     }
 
     def editNewsItemsSettings() {
+        if (!userService.isAdmin()) {
+            response.sendError(SC_FORBIDDEN, message(code: 'project.backend.permssion'))
+        }
+
         def projectInstance = Project.get(params.int("id"))
         if (!projectInstance) {
             flash.message = "${message(code: 'default.not.found.message', args: [message(code: 'project.label', default: 'Project'), params.id])}"
@@ -486,6 +518,9 @@ class ProjectController {
     }
 
     def updateGeneralSettings() {
+        if (!userService.isAdmin()) {
+            response.sendError(SC_FORBIDDEN, message(code: 'project.backend.permssion'))
+        }
 
         def projectInstance = Project.get(params.id)
         if (projectInstance) {
@@ -514,6 +549,10 @@ class ProjectController {
     }
 
     def update() {
+        if (!userService.isAdmin()) {
+            response.sendError(SC_FORBIDDEN, message(code: 'project.backend.permssion'))
+        }
+
         def projectInstance = Project.get(params.id)
         if (projectInstance) {
             if (!saveProjectSettingsFromParams(projectInstance, params)) {
@@ -528,6 +567,10 @@ class ProjectController {
     }
 
     def updateTutorialLinksSettings() {
+        if (!userService.isAdmin()) {
+            response.sendError(SC_FORBIDDEN, message(code: 'project.backend.permssion'))
+        }
+
         def projectInstance = Project.get(params.id)
         if (projectInstance) {
             if (!saveProjectSettingsFromParams(projectInstance, params)) {
@@ -543,6 +586,9 @@ class ProjectController {
     }
 
     def updateNewsItemsSettings() {
+        if (!userService.isAdmin()) {
+            response.sendError(SC_FORBIDDEN, message(code: 'project.backend.permssion'))
+        }
 
         def projectInstance = Project.get(params.id)
         if (projectInstance) {
@@ -559,18 +605,29 @@ class ProjectController {
 
 
     def deleteAllTasksFragment() {
+        if (!userService.isAdmin()) {
+            response.sendError(SC_FORBIDDEN, message(code: 'project.backend.permssion'))
+        }
+
         def projectInstance = Project.get(params.int("id"))
         def taskCount = Task.countByProject(projectInstance)
         [projectInstance: projectInstance, taskCount: taskCount]
     }
 
     def deleteProjectFragment() {
+        if (!userService.isAdmin()) {
+            response.sendError(SC_FORBIDDEN, message(code: 'project.backend.permssion'))
+        }
+
         def projectInstance = Project.get(params.int("id"))
         def taskCount = Task.countByProject(projectInstance)
         [projectInstance: projectInstance, taskCount: taskCount]
     }
 
     private boolean saveProjectSettingsFromParams(Project projectInstance, GrailsParameterMap params) {
+        if (!userService.isAdmin()) {
+            response.sendError(SC_FORBIDDEN, message(code: 'project.backend.permssion'))
+        }
 
         if (projectInstance) {
             if (params.version) {
@@ -592,6 +649,10 @@ class ProjectController {
     }
 
     def updatePicklistSettings() {
+        if (!userService.isAdmin()) {
+            response.sendError(SC_FORBIDDEN, message(code: 'project.backend.permssion'))
+        }
+
         def projectInstance = Project.get(params.id)
         if (projectInstance) {
             if (!saveProjectSettingsFromParams(projectInstance, params)) {
@@ -608,6 +669,10 @@ class ProjectController {
 
 
     def delete() {
+        if (!userService.isAdmin()) {
+            response.sendError(SC_FORBIDDEN, message(code: 'project.backend.permssion'))
+        }
+
         def projectInstance = Project.get(params.id)
         if (projectInstance) {
             try {
@@ -627,6 +692,10 @@ class ProjectController {
     }
     
     def uploadFeaturedImage() {
+        if (!userService.isAdmin()) {
+            response.sendError(SC_FORBIDDEN, message(code: 'project.backend.permssion'))
+        }
+
         def projectInstance = Project.get(params.id)
 
         projectInstance.featuredImageCopyright = params.featuredImageCopyright
@@ -663,6 +732,10 @@ class ProjectController {
     }
 
     def uploadBackgroundImage() {
+        if (!userService.isAdmin()) {
+            response.sendError(SC_FORBIDDEN, message(code: 'project.backend.permssion'))
+        }
+
         def projectInstance = Project.get(params.id)
 
         projectInstance.backgroundImageAttribution = params.backgroundImageAttribution
@@ -705,6 +778,10 @@ class ProjectController {
 
 
     def clearBackgroundImageSettings() {
+        if (!userService.isAdmin()) {
+            response.sendError(SC_FORBIDDEN, message(code: 'project.backend.permssion'))
+        }
+
         Project projectInstance = Project.get(params.id)
         if (projectInstance) {
             projectInstance.backgroundImageAttribution = null
@@ -717,6 +794,10 @@ class ProjectController {
     }
 
     def resizeExpeditionImage() {
+        if (!userService.isAdmin()) {
+            response.sendError(SC_FORBIDDEN, message(code: 'project.backend.permssion'))
+        }
+
         def projectInstance = Project.get(params.int("id"))
         if (projectInstance) {
             projectService.checkAndResizeExpeditionImage(projectInstance)
@@ -725,6 +806,10 @@ class ProjectController {
     }
 
     def setLeaderIconIndex() {
+        if (!userService.isAdmin()) {
+            response.sendError(SC_FORBIDDEN, message(code: 'project.backend.permssion'))
+        }
+
         if (params.id) {
             def project = Project.get(params.id)
             if (project) {
@@ -750,6 +835,10 @@ class ProjectController {
     }
 
     def updateMapSettings() {
+        if (!userService.isAdmin()) {
+            response.sendError(SC_FORBIDDEN, message(code: 'project.backend.permssion'))
+        }
+
         def projectInstance = Project.get(params.int("id"))
         if (projectInstance) {
             def showMap = params.showMap == "on"
@@ -861,6 +950,12 @@ class ProjectController {
     }
 
     def wizard(String id) {
+        render userService.currentUser.getUserRoles() as JSON
+
+        if (!userService.isAdmin()) {
+            response.sendError(SC_FORBIDDEN, message(code: 'project.backend.permssion'))
+        }
+
         if (!id) {
             def stagingId = UUID.randomUUID().toString()
             projectStagingService.ensureStagingDirectoryExists(stagingId)
@@ -992,6 +1087,7 @@ class ProjectController {
         if (!userService.isAdmin()) {
             response.sendError(SC_FORBIDDEN, message(code: 'project.backend.permssion'))
         }
+
         try {
             def body = request.getJSON()
             body.createdBy = userService.getCurrentUserId()

--- a/grails-app/controllers/au/org/ala/volunteer/SettingController.groovy
+++ b/grails-app/controllers/au/org/ala/volunteer/SettingController.groovy
@@ -1,8 +1,9 @@
 package au.org.ala.volunteer
 
+import au.org.ala.web.AlaSecured
 import java.lang.reflect.Modifier
 
-
+@AlaSecured(value = ["ROLE_VP_ADMIN"], redirectController = "index")
 class SettingController {
 
     def settingsService

--- a/grails-app/controllers/au/org/ala/volunteer/StatsController.groovy
+++ b/grails-app/controllers/au/org/ala/volunteer/StatsController.groovy
@@ -1,8 +1,10 @@
 package au.org.ala.volunteer
 
 import au.com.bytecode.opencsv.CSVWriter
+import au.org.ala.web.AlaSecured
 import grails.converters.JSON
 
+@AlaSecured(value = ["ROLE_VP_ADMIN"], redirectController = "index")
 class StatsController {
 
     static int defaultDayDiff = 7;

--- a/grails-app/controllers/au/org/ala/volunteer/TaskController.groovy
+++ b/grails-app/controllers/au/org/ala/volunteer/TaskController.groovy
@@ -1,5 +1,6 @@
 package au.org.ala.volunteer
 
+import au.org.ala.web.AlaSecured
 import grails.converters.JSON
 import groovy.time.TimeCategory
 import grails.web.servlet.mvc.GrailsParameterMap
@@ -11,6 +12,7 @@ import javax.servlet.http.HttpServletResponse
 import static javax.servlet.http.HttpServletResponse.SC_NO_CONTENT
 import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST
 
+@AlaSecured(value = ["ROLE_VP_ADMIN"], redirectController = "index")
 class TaskController {
 
     static allowedMethods = [save: "POST", update: "POST", delete: "POST", viewTask: "POST"]

--- a/grails-app/controllers/au/org/ala/volunteer/TemplateController.groovy
+++ b/grails-app/controllers/au/org/ala/volunteer/TemplateController.groovy
@@ -2,6 +2,7 @@ package au.org.ala.volunteer
 
 import grails.converters.JSON
 import org.springframework.web.multipart.MultipartFile
+import static javax.servlet.http.HttpServletResponse.SC_FORBIDDEN
 
 class TemplateController {
 
@@ -16,6 +17,10 @@ class TemplateController {
     }
 
     def list() {
+        if (!userService.isAdmin()) {
+            response.sendError(SC_FORBIDDEN)
+        }
+
         params.max = Math.min(params.max ? params.int('max') : 10, 100)
         [templateInstanceList: Template.list(params), templateInstanceTotal: Template.count()]
     }

--- a/grails-app/controllers/au/org/ala/volunteer/ValidationRuleController.groovy
+++ b/grails-app/controllers/au/org/ala/volunteer/ValidationRuleController.groovy
@@ -1,5 +1,8 @@
 package au.org.ala.volunteer
 
+import au.org.ala.web.AlaSecured
+
+@AlaSecured(value = ["ROLE_VP_ADMIN"], redirectController = "index")
 class ValidationRuleController {
 
     def index() {


### PR DESCRIPTION
Fixes AgentschapPlantentuinMeise/DoeDat-dev#43

Protected entire controllers instead of separate pages where it seemed
like the best option.

Tested these pages, they're reachable as an admin user but not as non-admin:

- /project/wizard
- /template/list
- /picklist/manage
- /validationRule/list
- /frontPage/edit
- /admin/leaderboard/index
- /stats/index
- /admin/tutorialManagement
- /admin/tools
- /admin/institutions/index
- /admin/achievements/index
- /setting/index ("you do not have permission", but can still edit)
- /admin/currentUsers
- /task/list/7426
- /project/editGeneralSettings/7426
- /admin/mailingList
- /ws/userReport?wt=csv
- /admin/projectSummaryReport