### PR TITLE
fix(user): remove leaked userInstance oject in JS on user page

### DIFF
--- a/grails-app/views/user/show.gsp
+++ b/grails-app/views/user/show.gsp
@@ -457,7 +457,6 @@
         selectedTab: selectedTab,
         defaultLatitude: grailsApplication.config.location.default.latitude,
         defaultLongitude: grailsApplication.config.location.default.longitude,
-        userInstance: userInstance,
         project: project,
         isValidator: isValidator,
         isAdmin: isAdmin,


### PR DESCRIPTION
Looks like this wasn't even used in the JavaScript code anyways.

Closes AgentschapPlantentuinMeise/DoeDat-dev#61