### PR TITLE
Set image container height to 500px

### DIFF
--- a/grails-app/views/transcribe/templateViews/aerialObservationsTranscribe.gsp
+++ b/grails-app/views/transcribe/templateViews/aerialObservationsTranscribe.gsp
@@ -8,7 +8,7 @@
         <title><cl:pageTitle title="${(validator) ? message(code: 'transcribe.templateViews.all.validate') : message(code: 'transcribe.templateViews.all.expedition')} ${taskInstance?.project?.i18nName}" /></title>
         <style type="text/css">
         #image-container {
-            height: 100px;
+            height: 500px;
         }
         </style>
     </head>


### PR DESCRIPTION
Set to same height as spreadsheetTranscribe, it's currently set to 100px which is so small we can't really use it for anything. Possibly it was meant for tabular data and only displaying a couple rows. But we want to try using the template for digital humanities projects. 